### PR TITLE
feat: add interactive code-slicing background and improve dark mode UX

### DIFF
--- a/app/[slug]/page.tsx
+++ b/app/[slug]/page.tsx
@@ -13,6 +13,9 @@ const postsDirectory = path.join(process.cwd(), 'posts');
 // 根据 slug 获取文章内容
 async function getPostData(slug: string) {
     const fullPath = path.join(postsDirectory, `${slug}.md`);
+    if (!fs.existsSync(fullPath)) {
+        return null;
+    }
     const fileContents = fs.readFileSync(fullPath, 'utf8');
 
     const { data, content } = matter(fileContents);
@@ -39,10 +42,10 @@ export default async function Post(props: { params: Promise<{ slug: string }> })
 
     return (
         <div className='animate-slideUp w-full'>
-            <h2 className="text-light-text [width:33ch] text-3xl font-bold m-auto"># {postData.title}</h2>
-            <p className="text-light-time prose m-auto">{postData.date}</p>
-            <div className="mt-8 text-light-body prose m-auto" dangerouslySetInnerHTML={{ __html: postData.contentHtml }} />
-            <div className='prose m-auto'>
+            <h2 className="text-light-text dark:text-dark-text [width:33ch] text-3xl font-bold m-auto"># {postData.title}</h2>
+            <p className="text-light-time dark:text-gray-400 prose dark:prose-invert m-auto">{postData.date}</p>
+            <div className="mt-8 text-light-body dark:text-gray-300 prose dark:prose-invert m-auto" dangerouslySetInnerHTML={{ __html: postData.contentHtml }} />
+            <div className='prose dark:prose-invert m-auto'>
                 <Link href='/blog' ><span>cd ..</span></Link>
             </div>
 

--- a/app/blog/page.tsx
+++ b/app/blog/page.tsx
@@ -64,20 +64,20 @@ export default async function Page() {
 
     return (
         <div className='w-full max-w-2xl mx-auto p-4 animate-slideUp'>
-            <h1 className='text-4xl mb-4'>posts</h1>
+            <h1 className='text-4xl mb-4 text-light-text dark:text-dark-text'>posts</h1>
             {Object.entries(groupByYear).map(([year, events]) => (
                 <div key={year} className='mt-20'>
                     <div className='relative text slide-enter pointer-events-none'>
-                        <div className=' absolute text-9xl opacity-10 font-bold -top-16 -left-10'>{year}</div>
+                        <div className=' absolute text-9xl opacity-10 font-bold -top-16 -left-10 text-light-text dark:text-dark-text'>{year}</div>
                     </div>
                     <ul>
                         {events.map(event => (
 
                             <div key={event.id} className='group'>
-                                <Link href={`/${event.id}`} className='text-xl text-light-focus group-hover:text-light-text transition duration-5000'>
+                                <Link href={`/${event.id}`} className='text-xl text-light-focus dark:text-dark-focus group-hover:text-light-text dark:group-hover:text-dark-text transition duration-5000'>
                                     <span >{event.title}</span>
                                 </Link>
-                                <span className='text-sm text-light-gray group-hover:text-light-focus cursor-pointer transition duration-5000'>&nbsp;&nbsp;&nbsp;{getMonthName(event.date)} {getDay(event.date)}</span>
+                                <span className='text-sm text-light-gray dark:text-dark-focus group-hover:text-light-focus dark:group-hover:text-dark-text cursor-pointer transition duration-5000'>&nbsp;&nbsp;&nbsp;{getMonthName(event.date)} {getDay(event.date)}</span>
                             </div>
                         ))}
                     </ul>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,24 +1,34 @@
 "use client"
+import CodeSliceBackground from "./ui/code-slice-background";
 import NavLink from "./ui/nav-link";
 import "./ui/global.css";
-import { useEffect, useState } from "react";
+import { useState } from "react";
 // 导出一个默认的React函数组件RootLayout，该组件接收一个包含children属性的对象作为参数
 export default function RootLayout({
   children,
 }: {
   children: React.ReactNode; // children属性的类型为React.ReactNode，表示可以是任何可以被渲染的React节点
 }) {
+
+  const [darkMode, setDarkMode] = useState(false);
+  const toggleDarkMode = () => {
+    setDarkMode(!darkMode);
+  }
   return (
     <html lang="en">
       <body>
-        <div className="flex h-screen flex-col md:flex-col md:overflow-hidden bg-light-background dark:bg-dark-background">
-          <div className="w-full flex flex-row-reverse mt-6 pr-10">
-            <NavLink />
-          </div>
-          <div className={"flex-grow p-6 md:overflow-y-auto md:p-10 "}>
-            {children}
+        <div className={darkMode ? 'dark' : ''}>
+          <div className="relative flex h-screen flex-col md:flex-col md:overflow-hidden bg-light-background dark:bg-dark-background transition-all duration-500">
+            <CodeSliceBackground darkMode={darkMode} />
+            <div className="relative z-10 w-full flex flex-row-reverse mt-6 pr-10">
+              <NavLink onAction={toggleDarkMode} darkMode={darkMode} />
+            </div>
+            <div className={"relative z-10 flex-grow p-6 md:overflow-y-auto md:p-10 "}>
+              {children}
+            </div>
           </div>
         </div>
+
       </body>
     </html>
   );

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -38,7 +38,7 @@ const contentHtml = remark().use(remarkHtml).processSync(markdownPage).toString(
 export default function Page() {
   return (
     <main>
-      <div className='mt-8 text-light-body prose animate-slideUp m-auto' dangerouslySetInnerHTML={{ __html: contentHtml }} />
+      <div className='mt-8 text-light-body dark:text-gray-300 prose dark:prose-invert animate-slideUp m-auto' dangerouslySetInnerHTML={{ __html: contentHtml }} />
     </main>
   );
 }

--- a/app/ui/code-slice-background.tsx
+++ b/app/ui/code-slice-background.tsx
@@ -1,0 +1,391 @@
+'use client';
+
+import { useEffect, useRef } from 'react';
+
+type CodeEntity = {
+  id: number;
+  text: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  gravity: number;
+  life: number;
+  maxLife: number;
+  size: number;
+  width: number;
+};
+
+type FeedbackEntity = {
+  id: number;
+  text: string;
+  x: number;
+  y: number;
+  vx: number;
+  vy: number;
+  life: number;
+  maxLife: number;
+  size: number;
+  kind: 'score' | 'combo';
+};
+
+const CODE_SNIPPETS = [
+  'const x = await fetchData()',
+  'useEffect(() => {}, [])',
+  'if (isDark) setTheme("dark")',
+  'return <main>{children}</main>',
+  'export default function Page()',
+  'type User = { id: string }',
+  'npm run build',
+  'git commit -m "feat"',
+  'for (const item of list) {}',
+  'console.log("hello world")',
+  'SELECT * FROM posts LIMIT 10;',
+  'pnpm add tailwindcss',
+];
+
+function randomBetween(min: number, max: number) {
+  return Math.random() * (max - min) + min;
+}
+
+export default function CodeSliceBackground({ darkMode }: { darkMode: boolean }) {
+  const canvasRef = useRef<HTMLCanvasElement | null>(null);
+  const entitiesRef = useRef<CodeEntity[]>([]);
+  const feedbacksRef = useRef<FeedbackEntity[]>([]);
+  const animationRef = useRef<number>(0);
+  const idRef = useRef(0);
+  const spawnAtRef = useRef(0);
+  const comboRef = useRef({
+    count: 0,
+    lastHitAt: 0,
+    flash: 0,
+  });
+  const mouseRef = useRef({
+    x: 0,
+    y: 0,
+    lastX: 0,
+    lastY: 0,
+    lastTs: 0,
+  });
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+
+    const context = canvas.getContext('2d');
+    if (!context) return;
+
+    const resize = () => {
+      const dpr = window.devicePixelRatio || 1;
+      canvas.width = Math.floor(window.innerWidth * dpr);
+      canvas.height = Math.floor(window.innerHeight * dpr);
+      canvas.style.width = `${window.innerWidth}px`;
+      canvas.style.height = `${window.innerHeight}px`;
+      context.setTransform(dpr, 0, 0, dpr, 0, 0);
+      context.textBaseline = 'middle';
+    };
+
+    const spawnCode = (mouseX: number, mouseY: number, ts: number) => {
+      if (ts - spawnAtRef.current < 2000) return;
+      if (entitiesRef.current.length > 34) return;
+      spawnAtRef.current = ts;
+
+      const snippet = CODE_SNIPPETS[Math.floor(Math.random() * CODE_SNIPPETS.length)];
+      const size = randomBetween(13, 17);
+      context.font = `600 ${size}px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`;
+      const width = context.measureText(snippet).width;
+
+      const startX = Math.max(
+        width / 2 + 8,
+        Math.min(window.innerWidth - width / 2 - 8, mouseX + randomBetween(-130, 130)),
+      );
+
+      const entity: CodeEntity = {
+        id: idRef.current++,
+        text: snippet,
+        x: startX,
+        y: window.innerHeight + randomBetween(20, 44),
+        vx: randomBetween(-0.8, 0.8),
+        vy: -8.2,
+        gravity: randomBetween(0.065, 0.095),
+        life: randomBetween(190, 260),
+        maxLife: 260,
+        size,
+        width,
+      };
+
+      const desiredPeakY = Math.max(52, Math.min(window.innerHeight - 80, mouseY + randomBetween(-48, 24)));
+      const travel = Math.max(120, entity.y - desiredPeakY);
+      entity.vy = -Math.sqrt(2 * entity.gravity * travel);
+
+      entitiesRef.current.push(entity);
+      if (entitiesRef.current.length > 42) {
+        entitiesRef.current.splice(0, entitiesRef.current.length - 42);
+      }
+    };
+
+    const splitEntity = (entity: CodeEntity, swipeDx: number, swipeDy: number, swipeSpeed: number) => {
+      const pivot = Math.max(1, Math.floor(entity.text.length / 2));
+      const leftText = entity.text.slice(0, pivot);
+      const rightText = entity.text.slice(pivot);
+      if (!leftText || !rightText) return;
+
+      const size = entity.size;
+      context.font = `600 ${size}px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`;
+
+      const leftWidth = context.measureText(leftText).width;
+      const rightWidth = context.measureText(rightText).width;
+      const speedBoost = Math.min(1.7, swipeSpeed * 0.04);
+      const distance = Math.hypot(swipeDx, swipeDy) || 1;
+      const directionX = swipeDx / distance;
+      const directionY = swipeDy / distance;
+      const normalX = -directionY;
+      const normalY = directionX;
+      const splitPush = randomBetween(1.3, 2.1) + speedBoost;
+
+      const leftEntity: CodeEntity = {
+        ...entity,
+        id: idRef.current++,
+        text: leftText,
+        x: entity.x - rightWidth * 0.22,
+        vx: entity.vx + normalX * splitPush - directionX * 0.45,
+        vy: entity.vy * 0.25 + normalY * splitPush * 0.35 - randomBetween(0.7, 1.2),
+        gravity: randomBetween(0.12, 0.18),
+        life: randomBetween(110, 170),
+        maxLife: 170,
+        width: leftWidth,
+      };
+
+      const rightEntity: CodeEntity = {
+        ...entity,
+        id: idRef.current++,
+        text: rightText,
+        x: entity.x + leftWidth * 0.22,
+        vx: entity.vx - normalX * splitPush + directionX * 0.45,
+        vy: entity.vy * 0.25 - normalY * splitPush * 0.35 - randomBetween(0.7, 1.2),
+        gravity: randomBetween(0.12, 0.18),
+        life: randomBetween(110, 170),
+        maxLife: 170,
+        width: rightWidth,
+      };
+
+      entitiesRef.current = entitiesRef.current
+        .filter((item) => item.id !== entity.id)
+        .concat(leftEntity, rightEntity);
+    };
+
+    const registerHitEffect = (x: number, y: number, ts: number) => {
+      const inComboWindow = ts - comboRef.current.lastHitAt <= 650;
+      comboRef.current.count = inComboWindow ? comboRef.current.count + 1 : 1;
+      comboRef.current.lastHitAt = ts;
+      comboRef.current.flash = Math.min(0.9, 0.26 + comboRef.current.count * 0.12);
+
+      const score = 8 + comboRef.current.count * 2;
+      feedbacksRef.current.push({
+        id: idRef.current++,
+        text: `+${score}`,
+        x: x + randomBetween(-8, 8),
+        y: y - randomBetween(8, 18),
+        vx: randomBetween(-0.3, 0.3),
+        vy: randomBetween(-1.5, -0.9),
+        life: 58,
+        maxLife: 58,
+        size: 13,
+        kind: 'score',
+      });
+
+      if (comboRef.current.count >= 2) {
+        feedbacksRef.current.push({
+          id: idRef.current++,
+          text: `x${comboRef.current.count} COMBO`,
+          x: x + randomBetween(-12, 12),
+          y: y - randomBetween(24, 34),
+          vx: randomBetween(-0.2, 0.2),
+          vy: randomBetween(-1.9, -1.2),
+          life: 72,
+          maxLife: 72,
+          size: 15,
+          kind: 'combo',
+        });
+      }
+
+      if (feedbacksRef.current.length > 28) {
+        feedbacksRef.current.splice(0, feedbacksRef.current.length - 28);
+      }
+    };
+
+    const segmentIntersectsEntity = (
+      x1: number,
+      y1: number,
+      x2: number,
+      y2: number,
+      entity: CodeEntity,
+    ) => {
+      const halfWidth = entity.width / 2 + 10;
+      const halfHeight = entity.size + 8;
+      const left = entity.x - halfWidth;
+      const right = entity.x + halfWidth;
+      const top = entity.y - halfHeight;
+      const bottom = entity.y + halfHeight;
+
+      if (
+        (x1 >= left && x1 <= right && y1 >= top && y1 <= bottom) ||
+        (x2 >= left && x2 <= right && y2 >= top && y2 <= bottom)
+      ) {
+        return true;
+      }
+
+      const minX = Math.min(x1, x2);
+      const maxX = Math.max(x1, x2);
+      const minY = Math.min(y1, y2);
+      const maxY = Math.max(y1, y2);
+      if (maxX < left || minX > right || maxY < top || minY > bottom) {
+        return false;
+      }
+
+      const edgeIntersects = (
+        ax: number,
+        ay: number,
+        bx: number,
+        by: number,
+        cx: number,
+        cy: number,
+        dx: number,
+        dy: number,
+      ) => {
+        const denominator = (bx - ax) * (dy - cy) - (by - ay) * (dx - cx);
+        if (Math.abs(denominator) < 0.00001) return false;
+        const r = ((ay - cy) * (dx - cx) - (ax - cx) * (dy - cy)) / denominator;
+        const s = ((ay - cy) * (bx - ax) - (ax - cx) * (by - ay)) / denominator;
+        return r >= 0 && r <= 1 && s >= 0 && s <= 1;
+      };
+
+      return (
+        edgeIntersects(x1, y1, x2, y2, left, top, right, top) ||
+        edgeIntersects(x1, y1, x2, y2, right, top, right, bottom) ||
+        edgeIntersects(x1, y1, x2, y2, right, bottom, left, bottom) ||
+        edgeIntersects(x1, y1, x2, y2, left, bottom, left, top)
+      );
+    };
+
+    const handleMouseMove = (event: MouseEvent) => {
+      const now = performance.now();
+      const prevX = mouseRef.current.lastX;
+      const prevY = mouseRef.current.lastY;
+      const dx = event.clientX - mouseRef.current.lastX;
+      const dy = event.clientY - mouseRef.current.lastY;
+      const dt = Math.max(8, now - mouseRef.current.lastTs || 16);
+      const distance = Math.hypot(dx, dy);
+      const speed = distance / dt;
+
+      mouseRef.current.x = event.clientX;
+      mouseRef.current.y = event.clientY;
+      mouseRef.current.lastX = event.clientX;
+      mouseRef.current.lastY = event.clientY;
+      mouseRef.current.lastTs = now;
+
+      spawnCode(event.clientX, event.clientY, now);
+
+      if (distance > 20 && speed > 0.85) {
+        const hit = entitiesRef.current.find((entity) => {
+          return segmentIntersectsEntity(prevX, prevY, event.clientX, event.clientY, entity);
+        });
+
+        if (hit) {
+          splitEntity(hit, dx, dy, speed);
+          registerHitEffect(event.clientX, event.clientY, now);
+        }
+      }
+    };
+
+    const tick = () => {
+      context.clearRect(0, 0, window.innerWidth, window.innerHeight);
+
+      comboRef.current.flash = Math.max(0, comboRef.current.flash * 0.9 - 0.015);
+      if (comboRef.current.flash > 0.01) {
+        const glowColor = darkMode ? '45, 212, 191' : '148, 163, 184';
+        const flashAlpha = comboRef.current.flash * (darkMode ? 0.18 : 0.13);
+        const gradient = context.createRadialGradient(
+          mouseRef.current.x,
+          mouseRef.current.y,
+          0,
+          mouseRef.current.x,
+          mouseRef.current.y,
+          180,
+        );
+        gradient.addColorStop(0, `rgba(${glowColor}, ${flashAlpha})`);
+        gradient.addColorStop(1, `rgba(${glowColor}, 0)`);
+        context.fillStyle = gradient;
+        context.fillRect(0, 0, window.innerWidth, window.innerHeight);
+      }
+
+      entitiesRef.current = entitiesRef.current.filter((entity) => {
+        entity.x += entity.vx;
+        entity.y += entity.vy;
+        entity.vy += entity.gravity;
+        entity.life -= 1;
+
+        const lifeAlpha = Math.max(0, Math.min(1, entity.life / entity.maxLife));
+        if (lifeAlpha <= 0) return false;
+        if (entity.y > window.innerHeight + 60) return false;
+        if (entity.x < -entity.width - 80 || entity.x > window.innerWidth + entity.width + 80) return false;
+
+        const color = darkMode ? '153, 246, 228' : '71, 85, 105';
+        context.font = `600 ${entity.size}px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`;
+        context.fillStyle = `rgba(${color}, ${0.26 + lifeAlpha * 0.52})`;
+        context.shadowColor = darkMode ? 'rgba(45, 212, 191, 0.35)' : 'rgba(148, 163, 184, 0.35)';
+        context.shadowBlur = 8;
+        context.fillText(entity.text, entity.x - entity.width / 2, entity.y);
+        context.shadowBlur = 0;
+        return true;
+      });
+
+      feedbacksRef.current = feedbacksRef.current.filter((feedback) => {
+        feedback.x += feedback.vx;
+        feedback.y += feedback.vy;
+        feedback.vy += 0.02;
+        feedback.life -= 1;
+
+        const lifeAlpha = Math.max(0, Math.min(1, feedback.life / feedback.maxLife));
+        if (lifeAlpha <= 0) return false;
+
+        const color = feedback.kind === 'combo'
+          ? (darkMode ? '45, 212, 191' : '15, 23, 42')
+          : (darkMode ? '153, 246, 228' : '30, 41, 59');
+        const shadow = feedback.kind === 'combo'
+          ? (darkMode ? 'rgba(45, 212, 191, 0.5)' : 'rgba(15, 23, 42, 0.25)')
+          : (darkMode ? 'rgba(45, 212, 191, 0.25)' : 'rgba(100, 116, 139, 0.25)');
+
+        context.font = `700 ${feedback.size}px ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace`;
+        context.fillStyle = `rgba(${color}, ${0.2 + lifeAlpha * 0.9})`;
+        context.shadowColor = shadow;
+        context.shadowBlur = feedback.kind === 'combo' ? 12 : 6;
+        context.fillText(feedback.text, feedback.x, feedback.y);
+        context.shadowBlur = 0;
+
+        return true;
+      });
+
+      animationRef.current = window.requestAnimationFrame(tick);
+    };
+
+    resize();
+    window.addEventListener('resize', resize);
+    window.addEventListener('mousemove', handleMouseMove, { passive: true });
+    animationRef.current = window.requestAnimationFrame(tick);
+
+    return () => {
+      window.removeEventListener('resize', resize);
+      window.removeEventListener('mousemove', handleMouseMove);
+      window.cancelAnimationFrame(animationRef.current);
+    };
+  }, [darkMode]);
+
+  return (
+    <canvas
+      ref={canvasRef}
+      className="pointer-events-none fixed inset-0 z-0"
+      aria-hidden="true"
+    />
+  );
+}

--- a/app/ui/nav-link.tsx
+++ b/app/ui/nav-link.tsx
@@ -16,7 +16,13 @@ const links = [
     //     href: "/projects",
     // }
 ]
-export default function NavLink() {
+export default function NavLink({
+    onAction,
+    darkMode,
+}: {
+    onAction: () => void;
+    darkMode: boolean;
+}) {
     const pathname = usePathname()
     return (
         <>
@@ -31,6 +37,25 @@ export default function NavLink() {
                         </Link>
                     )
                 })}
+                <button
+                    type="button"
+                    onClick={onAction}
+                    aria-label="Toggle dark mode"
+                    aria-pressed={darkMode}
+                    className="md:mt-2 md:text-center mr-5 mt-3 inline-flex items-center justify-center text-light-focus hover:text-light-text dark:text-dark-focus dark:hover:text-dark-text transition"
+                >
+                    {darkMode ? (
+                        <svg viewBox="0 0 24 24" fill="currentColor" className="h-5 w-5" aria-hidden="true">
+                            <path d="M21 13.2A9 9 0 1 1 10.8 3a7 7 0 1 0 10.2 10.2Z" />
+                        </svg>
+                    ) : (
+                        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" className="h-5 w-5" aria-hidden="true">
+                            <circle cx="12" cy="12" r="4" strokeWidth="2" />
+                            <path strokeLinecap="round" strokeWidth="2" d="M12 2.5v2.2M12 19.3v2.2M4.9 4.9l1.5 1.5M17.6 17.6l1.5 1.5M2.5 12h2.2M19.3 12h2.2M4.9 19.1l1.5-1.5M17.6 6.4l1.5-1.5" />
+                        </svg>
+                    )}
+                </button>
+
             </div>
         </>
     )

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -28,11 +28,12 @@ const config: Config = {
           body: '#4f4f4f',
         },
         dark: {
-          background: '#000000',
+          background: '#121212',
           text: '#ffffff',
           primary: '#00bcd4',
           hover: '#009ca3',
           focus: '#77787b',
+          h1: '#ffffff',
         },
       },
     },

--- a/vercel.json
+++ b/vercel.json
@@ -1,3 +1,3 @@
 {
-  "installCommand": "npx bun@1.0.21 install"
+  "installCommand": "pnpm install --frozen-lockfile"
 }


### PR DESCRIPTION
- add a canvas-based background that throws random code snippets from below
- support fast-swipe slicing with split/fall animation and combo feedback effects
- integrate global dark mode state in layout and hook it to nav theme toggle
- replace text theme switch with sun/moon SVG icon button in the nav
- improve dark mode readability across home, blog list, and post detail pages
- handle missing markdown posts gracefully by returning 404 instead of ENOENT
- refine dark theme palette values in Tailwind config